### PR TITLE
parse bytestrings (square brackets) as hex

### DIFF
--- a/dtcanon.py
+++ b/dtcanon.py
@@ -218,7 +218,7 @@ def parse_value(r):
                     raise ParseError(r, f"Invalid hex character: {r.next}")
                 digits += r.next
                 r.consume()
-                num = int(digits)
+                num = int(digits, base=16)
                 value += bytes(str(digits, "utf-8").lower(), "utf-8")
 
             value += b"]"


### PR DESCRIPTION
`int(s)` defaults to base 10, while (according to the spec) [bytestrings are represented by pairs of hex digits](https://devicetree-specification.readthedocs.io/en/latest/chapter6-source-language.html#node-and-property-definitions). Change the bytestring parser to specify `base=16`.

Fixes #1.
